### PR TITLE
fix: dropped packed

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
   },
   "homepage": "https://github.com/libp2p/js-libp2p-multiplex#readme",
   "devDependencies": {
-    "aegir": "^9.3.2",
+    "aegir": "^9.3.3",
     "chai": "^3.5.0",
-    "interface-stream-muxer": "^0.5.4",
+    "interface-stream-muxer": "^0.5.5",
     "libp2p-websockets": "^0.9.1",
     "pre-commit": "^1.2.2",
     "pull-pair": "^1.1.0"

--- a/src/index.js
+++ b/src/index.js
@@ -10,8 +10,6 @@ const pump = require('pump')
 
 function create (rawConn, isListener) {
   const stream = toStream(rawConn)
-  // Let it flow, let it flooow
-  stream.resume()
 
   stream.on('end', () => {
     // Cleanup and destroy the connection when it ends
@@ -21,8 +19,7 @@ function create (rawConn, isListener) {
   })
 
   const mpx = multiplex()
-  pump(mpx, stream)
-  pump(stream, mpx)
+  pump(stream, mpx, stream)
 
   return new Muxer(rawConn, mpx, isListener)
 }


### PR DESCRIPTION
@VictorBjelkholm after some long hours of debugging, we managed to find the issue.

multiplex from the listener side was opening the streams before the dialer had the time to mount the muxer and so, when it got to mount the muxer, some data events were already emitted because of the resume call.

This was super tough one to fix! Big thanks for @pgte for pairing with me debugging it.

//cc @dignifiedquire you will find this hilarious
//cc @haadcode @RichardLitt stream muxer is under way!