### PR TITLE
fix: handling socket disconnect error gracefully

### DIFF
--- a/src/muxer.js
+++ b/src/muxer.js
@@ -9,6 +9,11 @@ const setImmediate = require('async/setImmediate')
 
 const MULTIPLEX_CODEC = require('./multiplex-codec')
 
+const OK_ERROR_MESSAGES = [
+  'Channel destroyed',
+  'underlying socket has been closed'
+]
+
 module.exports = class MultiplexMuxer extends EventEmitter {
   constructor (conn, multiplex) {
     super()
@@ -58,7 +63,7 @@ function catchError (stream) {
     source: pull(
       stream.source,
       pullCatch((err) => {
-        if (err.message === 'Channel destroyed') {
+        if (OK_ERROR_MESSAGES.indexOf(err.message) >= 0) {
           return
         }
         return false


### PR DESCRIPTION
Not propagating some error messages that depict that the underlying resource has been closed.
Added an error message to the original `Channel destroyed` one.
Should fix https://github.com/ipfs/js-ipfs/issues/883